### PR TITLE
fix: change ffmpeg option to fix color matrix

### DIFF
--- a/electron/converter.ts
+++ b/electron/converter.ts
@@ -22,7 +22,7 @@ const startConverter = async (queue: ConvertQueue): Promise<void> => {
     pix_fmt: "yuv420p",
     "b:v": "0",
     crf: "30",
-    filter_complex: `[0:v]fps=fps=${queue.option.fps},pad=width=max(iw\\, ih*(16/9)):height=ow/(16/9):x=(ow-iw)/2:y=(oh-ih)/2,scale=w=1920:h=1080[3];[3][1:v]overlay=format=rgb[out_v]`,
+    filter_complex: `[0:v]fps=fps=${queue.option.fps},pad=width=max(iw\\, ih*(16/9)):height=ow/(16/9):x=(ow-iw)/2:y=(oh-ih)/2,scale=w=1920:h=1080[3];[1:v]scale=out_color_matrix=bt709[4];[3][4]overlay=format=rgb[out_v]`,
     "map:v": "[out_v]",
     "map:a": "0:a",
     r: queue.option.fps,


### PR DESCRIPTION
#24 について、出力後のフォーマットを指定した際に再度色が狂ってしまっていたため修正
参考: https://github.com/k4yt3x/video2x/issues/403