### PR TITLE
fix: armチップのmac用ビルドが破損していると表示される不具合を修正

### DIFF
--- a/build-script/mac.js
+++ b/build-script/mac.js
@@ -9,7 +9,7 @@ builder.build({
                 'target': 'dmg',
                 'arch': [
                     'x64',
-                    'arm64'
+                    'universal'
                 ]
             }
         }


### PR DESCRIPTION
ref: https://github.com/electron-userland/electron-builder/issues/5850