### PR TITLE
[修正] DMSのみの動画からコメントをダウンロードできない不具合を修正

### DIFF
--- a/src/controller/comment-picker/remote/remote-comment-picker.tsx
+++ b/src/controller/comment-picker/remote/remote-comment-picker.tsx
@@ -63,13 +63,6 @@ const RemoteCommentPicker: FC<Props> = ({ onChange }) => {
         });
         return;
       }
-      if (!targetMetadata.data.media.delivery) {
-        setMessage({
-          title: "動画情報の取得に失敗しました",
-          content: "未購入の有料動画などの可能性があります",
-        });
-        return;
-      }
       setMetadata(targetMetadata);
       setMode(targetMetadata.data.viewer === null ? "simple" : "custom");
       lastUrl.current = nicoId;

--- a/src/controller/convert/convert.tsx
+++ b/src/controller/convert/convert.tsx
@@ -336,7 +336,7 @@ const Convert: FC = () => {
                   <FormControl key={key} variant="standard">
                     <InputLabel>{item.name}</InputLabel>
                     <Select
-                      value={item.value}
+                      value={`${item.value}`}
                       onChange={(e) =>
                         setOptions({
                           ...options,


### PR DESCRIPTION
- dmcの値を確認してなければエラーにしていた
- dmsのみの動画が出てきて、動画の方は処理を修正したがコメントの方の修正が漏れていた

close #93 