### PR TITLE
[更新] v3 API を Watch Page API に置き換え

### DIFF
--- a/electron/lib/niconico/dmc.ts
+++ b/electron/lib/niconico/dmc.ts
@@ -1,4 +1,8 @@
-import type { CreateSessionRequest, TWatchV3Metadata } from "@/@types/niconico";
+import type {
+  CreateSessionRequest,
+  TWatchV3Metadata,
+  V3MetadataBody,
+} from "@/@types/niconico";
 import type { TDMCFormat } from "@/@types/queue";
 import type { SpawnResult } from "@/@types/spawn";
 
@@ -9,7 +13,7 @@ import { DownloadM3U8 } from "../../utils/ffmpeg";
 let stop: (() => void) | undefined;
 
 const downloadDMC = async (
-  metadata: TWatchV3Metadata,
+  metadata: V3MetadataBody,
   format: TDMCFormat,
   path: string,
   progress: (total: number, downloaded: number, eta: number) => void,
@@ -32,10 +36,10 @@ const downloadDMC = async (
     });
     return;
   }
-  if (metadata.data.media.delivery.trackingId) {
+  if (metadata.media.delivery.trackingId) {
     const trackingReq = await fetch(
       `https://nvapi.nicovideo.jp/v1/2ab0cbaa/watch?${new URLSearchParams({
-        t: metadata.data.media.delivery.trackingId,
+        t: metadata.media.delivery.trackingId,
       }).toString()}`,
       {
         method: "GET",
@@ -137,22 +141,21 @@ const downloadDMC = async (
 };
 
 const createSessionCreateRequestBody = (
-  metadata: TWatchV3Metadata<"dmc">,
+  metadata: V3MetadataBody<"dmc">,
   format: TDMCFormat,
 ): CreateSessionRequest => {
   const sessionBody: CreateSessionRequest = {
     session: {
       client_info: {
-        player_id: metadata.data.media.delivery.movie.session.playerId,
+        player_id: metadata.media.delivery.movie.session.playerId,
       },
       content_auth: {
         auth_type: "ht2",
         content_key_timeout: 600000,
         service_id: "nicovideo",
-        service_user_id:
-          metadata.data.media.delivery.movie.session.serviceUserId,
+        service_user_id: metadata.media.delivery.movie.session.serviceUserId,
       },
-      content_id: metadata.data.media.delivery.movie.contentId,
+      content_id: metadata.media.delivery.movie.contentId,
       content_src_id_sets: [
         {
           content_src_ids: [
@@ -169,11 +172,10 @@ const createSessionCreateRequestBody = (
       content_uri: "",
       keep_method: {
         heartbeat: {
-          lifetime:
-            metadata.data.media.delivery.movie.session.heartbeatLifetime,
+          lifetime: metadata.media.delivery.movie.session.heartbeatLifetime,
         },
       },
-      priority: metadata.data.media.delivery.movie.session.priority,
+      priority: metadata.media.delivery.movie.session.priority,
       protocol: {
         name: "http",
         parameters: {
@@ -182,8 +184,8 @@ const createSessionCreateRequestBody = (
               hls_parameters: {
                 segment_duration: 6000,
                 transfer_preset:
-                  metadata.data.media.delivery.movie.session
-                    .transferPresets[0] || "",
+                  metadata.media.delivery.movie.session.transferPresets[0] ||
+                  "",
                 use_ssl: "yes",
                 use_well_known_port: "yes",
               },
@@ -191,22 +193,22 @@ const createSessionCreateRequestBody = (
           },
         },
       },
-      recipe_id: metadata.data.media.delivery.recipeId,
+      recipe_id: metadata.media.delivery.recipeId,
       session_operation_auth: {
         session_operation_auth_by_signature: {
-          signature: metadata.data.media.delivery.movie.session.signature,
-          token: metadata.data.media.delivery.movie.session.token,
+          signature: metadata.media.delivery.movie.session.signature,
+          token: metadata.media.delivery.movie.session.token,
         },
       },
       timing_constraint: "unlimited",
     },
   };
-  if (metadata.data.media.delivery.encryption) {
+  if (metadata.media.delivery.encryption) {
     sessionBody.session.protocol.parameters.http_parameters.parameters.hls_parameters.encryption =
       {
         hls_encryption_v1: {
-          encrypted_key: metadata.data.media.delivery.encryption.encryptedKey,
-          key_uri: metadata.data.media.delivery.encryption.keyUri,
+          encrypted_key: metadata.media.delivery.encryption.encryptedKey,
+          key_uri: metadata.media.delivery.encryption.keyUri,
         },
       };
   }

--- a/electron/lib/niconico/dms.ts
+++ b/electron/lib/niconico/dms.ts
@@ -1,5 +1,5 @@
 import type { Cookies } from "@/@types/cookies";
-import type { TWatchV3Metadata } from "@/@types/niconico";
+import type { TWatchV3Metadata, V3MetadataBody } from "@/@types/niconico";
 import type { TDMSFormat } from "@/@types/queue";
 import type { AuthType } from "@/@types/setting";
 import type { SpawnResult } from "@/@types/spawn";
@@ -18,7 +18,7 @@ import {
 let stop: (() => void) | undefined;
 
 const downloadDMS = async (
-  metadata: TWatchV3Metadata,
+  metadata: V3MetadataBody,
   format: TDMSFormat,
   targetPath: string,
   progress: (total: number, downloaded: number, eta: number) => void,
@@ -50,14 +50,14 @@ const downloadDMS = async (
     return undefined;
   })();
   const accessRightsReq = await fetch(
-    `https://nvapi.nicovideo.jp/v1/watch/${metadata.data.video.id}/access-rights/hls?actionTrackId=0_0`,
+    `https://nvapi.nicovideo.jp/v1/watch/${metadata.video.id}/access-rights/hls?actionTrackId=0_0`,
     {
       headers: {
         Host: "nvapi.nicovideo.jp",
         Cookie: cookie ? convertToEncodedCookie(cookie) : "",
         "Content-Type": "application/json",
         "X-Request-With": "https://www.nicovideo.jp",
-        "X-Access-Right-Key": metadata.data.media.domand.accessRightKey,
+        "X-Access-Right-Key": metadata.media.domand.accessRightKey,
         "X-Frontend-Id": "6",
         "X-Frontend-Version": "0",
       },

--- a/electron/type-guard.ts
+++ b/electron/type-guard.ts
@@ -9,6 +9,8 @@ import type {
   TWatchV3Metadata,
   UserData,
   V1AccessRightsHls,
+  V3MetadataBody,
+  WatchPageMetadata,
 } from "@/@types/niconico";
 import type {
   ApiRequestAppendQueue,
@@ -138,6 +140,11 @@ const typeGuard = {
       typeof i === "object" &&
       (i as TWatchV3Metadata).meta.status === 200 &&
       typeof (i as TWatchV3Metadata).data === "object",
+    WatchPageJson: (i: unknown): i is WatchPageMetadata =>
+      typeof i === "object" &&
+      (i as WatchPageMetadata).meta.status === 200 &&
+      typeof (i as WatchPageMetadata).data === "object" &&
+      typeof (i as WatchPageMetadata).data.response === "object",
     CreateSessionResponse: (i: unknown): i is CreateSessionResponse =>
       typeof i === "object" &&
       ((i as CreateSessionResponse).meta.status === 201 ||
@@ -145,10 +152,10 @@ const typeGuard = {
       ((i as CreateSessionResponse).meta.message === "created" ||
         (i as CreateSessionResponse).meta.message === "ok") &&
       typeof (i as CreateSessionResponse).data === "object",
-    v3DMC: (i: unknown): i is TWatchV3Metadata<"dmc"> =>
-      typeof i === "object" && !!(i as TWatchV3Metadata).data.media.delivery,
-    v3DMS: (i: unknown): i is TWatchV3Metadata<"dms"> =>
-      typeof i === "object" && !!(i as TWatchV3Metadata).data.media.domand,
+    v3DMC: (i: unknown): i is V3MetadataBody<"dmc"> =>
+      typeof i === "object" && !!(i as V3MetadataBody).media.delivery,
+    v3DMS: (i: unknown): i is V3MetadataBody<"dms"> =>
+      typeof i === "object" && !!(i as V3MetadataBody).media.domand,
     v1AccessRightsHls: (i: unknown): i is V1AccessRightsHls =>
       typeof i === "object" &&
       (i as V1AccessRightsHls).meta.status === 201 &&

--- a/src/@types/niconico.d.ts
+++ b/src/@types/niconico.d.ts
@@ -2,48 +2,57 @@ export type TWatchV3Metadata<T extends "dmc" | "dms" | "" = ""> = {
   meta: {
     status: 200;
   };
-  data: {
-    comment: V3MetadataComment;
-    media: {
-      delivery: T extends "dmc"
-        ? V3MetadataDMCMedia
-        : V3MetadataDMCMedia | null;
-      domand: T extends "dms" ? V3MetadataDMSMedia : V3MetadataDMSMedia | null;
-    };
-    video: {
-      id: string;
-      title: string;
-      description: string;
-      count: {
-        view: number;
-        comment: number;
-        mylist: number;
-        like: number;
-      };
-      duration: number;
-      thumbnail: {
-        url: string;
-        middleUrl: string;
-        largeUrl: string;
-        player: string;
-        ogp: string;
-      };
-      rating: {
-        isAdult: boolean;
-      };
-      registeredAt: string;
-      isPrivate: boolean;
-      isDeleted: boolean;
-      isNoBanner: boolean;
-      isAuthenticationRequired: boolean;
-      isEmbedPlayerAllowed: boolean;
-      viewer: unknown;
-      watchableUserTypeForPayment: string;
-      commentableUserTypeForPayment: string;
-      "9d091f87": boolean;
-    };
-    viewer: V3MetadataViewerItem | null;
+  data: V3MetadataBody<T>;
+};
+
+export type WatchPageMetadata<T extends "dmc" | "dms" | "" = ""> = {
+  meta: {
+    status: 200;
   };
+  data: {
+    response: V3MetadataBody;
+  };
+};
+
+export type V3MetadataBody<T extends "dmc" | "dms" | "" = ""> = {
+  comment: V3MetadataComment;
+  media: {
+    delivery: T extends "dmc" ? V3MetadataDMCMedia : V3MetadataDMCMedia | null;
+    domand: T extends "dms" ? V3MetadataDMSMedia : V3MetadataDMSMedia | null;
+  };
+  video: {
+    id: string;
+    title: string;
+    description: string;
+    count: {
+      view: number;
+      comment: number;
+      mylist: number;
+      like: number;
+    };
+    duration: number;
+    thumbnail: {
+      url: string;
+      middleUrl: string;
+      largeUrl: string;
+      player: string;
+      ogp: string;
+    };
+    rating: {
+      isAdult: boolean;
+    };
+    registeredAt: string;
+    isPrivate: boolean;
+    isDeleted: boolean;
+    isNoBanner: boolean;
+    isAuthenticationRequired: boolean;
+    isEmbedPlayerAllowed: boolean;
+    viewer: unknown;
+    watchableUserTypeForPayment: string;
+    commentableUserTypeForPayment: string;
+    "9d091f87": boolean;
+  };
+  viewer: V3MetadataViewerItem | null;
 };
 
 export type V3MetadataViewerItem = {

--- a/src/controller/movie-picker/remote/dmc/dmc.tsx
+++ b/src/controller/movie-picker/remote/dmc/dmc.tsx
@@ -2,14 +2,14 @@ import { MenuItem, Select } from "@mui/material";
 import type { FC } from "react";
 import { useEffect, useState } from "react";
 
-import type { TWatchV3Metadata } from "@/@types/niconico";
+import type { TWatchV3Metadata, V3MetadataBody } from "@/@types/niconico";
 import type { TDMCFormat } from "@/@types/queue";
 import { SelectField } from "@/components/select-field";
 import Styles from "@/controller/movie/movie.module.scss";
 import { getDMCBestSegment } from "@/util/niconico";
 
 type Props = {
-  metadata: TWatchV3Metadata<"dmc">;
+  metadata: V3MetadataBody<"dmc">;
   onChange: (val: TDMCFormat | undefined) => void;
 };
 
@@ -18,10 +18,10 @@ const DMCMoviePicker: FC<Props> = ({ metadata, onChange }) => {
   const [selectedAudio, setSelectedAudio] = useState<string>("");
   useEffect(() => {
     setSelectedAudio(
-      getDMCBestSegment(metadata.data.media.delivery.movie.audios).id,
+      getDMCBestSegment(metadata.media.delivery.movie.audios).id,
     );
     setSelectedVideo(
-      getDMCBestSegment(metadata.data.media.delivery.movie.videos).id,
+      getDMCBestSegment(metadata.media.delivery.movie.videos).id,
     );
   }, [metadata]);
   useEffect(() => {
@@ -41,12 +41,12 @@ const DMCMoviePicker: FC<Props> = ({ metadata, onChange }) => {
           variant={"standard"}
           value={selectedVideo}
           defaultValue={
-            getDMCBestSegment(metadata.data.media.delivery.movie.videos).id
+            getDMCBestSegment(metadata.media.delivery.movie.videos).id
           }
           className={Styles.input}
           onChange={(e) => setSelectedVideo(e.target.value)}
         >
-          {metadata.data.media.delivery.movie.videos.map((val) => {
+          {metadata.media.delivery.movie.videos.map((val) => {
             if (!val.isAvailable) return <></>;
             return (
               <MenuItem key={val.id} value={val.id}>
@@ -62,12 +62,12 @@ const DMCMoviePicker: FC<Props> = ({ metadata, onChange }) => {
           variant={"standard"}
           className={Styles.input}
           defaultValue={
-            getDMCBestSegment(metadata.data.media.delivery.movie.audios).id
+            getDMCBestSegment(metadata.media.delivery.movie.audios).id
           }
           value={selectedAudio}
           onChange={(e) => setSelectedAudio(e.target.value)}
         >
-          {metadata.data.media.delivery.movie.audios.map((val) => {
+          {metadata.media.delivery.movie.audios.map((val) => {
             if (!val.isAvailable) return <></>;
             return (
               <MenuItem key={val.id} value={val.id}>

--- a/src/controller/movie-picker/remote/dms/dms.tsx
+++ b/src/controller/movie-picker/remote/dms/dms.tsx
@@ -2,14 +2,14 @@ import { MenuItem, Select } from "@mui/material";
 import type { FC } from "react";
 import { useEffect, useState } from "react";
 
-import type { TWatchV3Metadata } from "@/@types/niconico";
+import type { TWatchV3Metadata, V3MetadataBody } from "@/@types/niconico";
 import type { TDMSFormat } from "@/@types/queue";
 import { SelectField } from "@/components/select-field";
 import Styles from "@/controller/movie/movie.module.scss";
 import { getDMSBestSegment } from "@/util/niconico";
 
 type Props = {
-  metadata: TWatchV3Metadata<"dms">;
+  metadata: V3MetadataBody<"dms">;
   onChange: (val: TDMSFormat | undefined) => void;
 };
 
@@ -17,8 +17,8 @@ const DMSMoviePicker: FC<Props> = ({ metadata, onChange }) => {
   const [selectedVideo, setSelectedVideo] = useState<string>("");
   const [selectedAudio, setSelectedAudio] = useState<string>("");
   useEffect(() => {
-    setSelectedAudio(getDMSBestSegment(metadata.data.media.domand.audios).id);
-    setSelectedVideo(getDMSBestSegment(metadata.data.media.domand.videos).id);
+    setSelectedAudio(getDMSBestSegment(metadata.media.domand.audios).id);
+    setSelectedVideo(getDMSBestSegment(metadata.media.domand.videos).id);
   }, [metadata]);
 
   useEffect(() => {
@@ -34,11 +34,11 @@ const DMSMoviePicker: FC<Props> = ({ metadata, onChange }) => {
           label={"動画"}
           variant={"standard"}
           value={selectedVideo}
-          defaultValue={getDMSBestSegment(metadata.data.media.domand.videos).id}
+          defaultValue={getDMSBestSegment(metadata.media.domand.videos).id}
           className={Styles.input}
           onChange={(e) => setSelectedVideo(e.target.value)}
         >
-          {metadata.data.media.domand.videos.map((val) => {
+          {metadata.media.domand.videos.map((val) => {
             if (!val.isAvailable) return <></>;
             return (
               <MenuItem key={val.id} value={val.id}>
@@ -53,11 +53,11 @@ const DMSMoviePicker: FC<Props> = ({ metadata, onChange }) => {
           label={"音声"}
           variant={"standard"}
           className={Styles.input}
-          defaultValue={getDMSBestSegment(metadata.data.media.domand.audios).id}
+          defaultValue={getDMSBestSegment(metadata.media.domand.audios).id}
           value={selectedAudio}
           onChange={(e) => setSelectedAudio(e.target.value)}
         >
-          {metadata.data.media.domand.audios.map((val) => {
+          {metadata.media.domand.audios.map((val) => {
             if (!val.isAvailable) return <></>;
             return (
               <MenuItem key={val.id} value={val.id}>

--- a/src/controller/movie-picker/remote/remote-movie-picker.tsx
+++ b/src/controller/movie-picker/remote/remote-movie-picker.tsx
@@ -4,7 +4,7 @@ import { useSetAtom } from "jotai";
 import type { ChangeEvent, FC, KeyboardEvent } from "react";
 import { useRef, useState } from "react";
 
-import type { TWatchV3Metadata } from "@/@types/niconico";
+import type { TWatchV3Metadata, V3MetadataBody } from "@/@types/niconico";
 import type {
   TMovieItemRemote,
   TRemoteMovieItemFormat,
@@ -24,7 +24,7 @@ type Props = {
 
 const RemoteMoviePicker: FC<Props> = ({ onChange }) => {
   const [url, setUrl] = useState("");
-  const [metadata, setMetadata] = useState<TWatchV3Metadata | undefined>();
+  const [metadata, setMetadata] = useState<V3MetadataBody | undefined>();
   const [mediaServer, setMediaServer] = useState<TRemoteServerType>("dmc");
   const [format, setFormat] = useState<TRemoteMovieItemFormat | undefined>();
   const setMessage = useSetAtom(messageAtom);
@@ -51,7 +51,7 @@ const RemoteMoviePicker: FC<Props> = ({ onChange }) => {
         type: "getNiconicoMovieMetadata",
         nicoId: nicoId,
         host: "controller",
-      })) as TWatchV3Metadata;
+      })) as V3MetadataBody;
       setIsLoading(false);
       if (!targetMetadata) {
         setMessage({
@@ -60,17 +60,14 @@ const RemoteMoviePicker: FC<Props> = ({ onChange }) => {
         });
         return;
       }
-      if (
-        !targetMetadata.data.media.delivery &&
-        !targetMetadata.data.media.domand
-      ) {
+      if (!targetMetadata.media.delivery && !targetMetadata.media.domand) {
         setMessage({
           title: "動画情報の取得に失敗しました",
           content: "未購入の有料動画などの可能性があります",
         });
         return;
       }
-      setMediaServer(targetMetadata.data.media.domand ? "dms" : "dmc");
+      setMediaServer(targetMetadata.media.domand ? "dms" : "dmc");
       setMetadata(targetMetadata);
       lastUrl.current = nicoId;
     })();
@@ -111,7 +108,7 @@ const RemoteMoviePicker: FC<Props> = ({ onChange }) => {
       onChange({
         type: "remote",
         path: output,
-        duration: metadata.data.video.duration,
+        duration: metadata.video.duration,
         ref: {
           id: uuid(),
           status: "queued",
@@ -150,12 +147,12 @@ const RemoteMoviePicker: FC<Props> = ({ onChange }) => {
               value={"dmc"}
               control={<Radio />}
               label={"DMC"}
-              disabled={!metadata.data.media.delivery}
+              disabled={!metadata.media.delivery}
             />
             <FormControlLabel
               value={"dms"}
               control={<Radio />}
-              disabled={!metadata.data.media.domand}
+              disabled={!metadata.media.domand}
               label={"DMS"}
             />
           </RadioGroup>

--- a/src/type-guard.ts
+++ b/src/type-guard.ts
@@ -1,4 +1,4 @@
-import type { TWatchV3Metadata } from "@/@types/niconico";
+import type { TWatchV3Metadata, V3MetadataBody } from "@/@types/niconico";
 import type { ApiResponseDownloadProgress } from "@/@types/response.binary-downloader";
 import type {
   ApiResponseEnd,
@@ -27,10 +27,10 @@ const typeGuard = {
       typeof i === "object" && (i as ApiResponseEnd).type === "end",
     message: (i: unknown): i is ApiResponseMessage =>
       typeof i === "object" && (i as ApiResponseMessage).type === "message",
-    v3DMC: (i: unknown): i is TWatchV3Metadata<"dmc"> =>
-      typeof i === "object" && !!(i as TWatchV3Metadata).data.media.delivery,
-    v3DMS: (i: unknown): i is TWatchV3Metadata<"dms"> =>
-      typeof i === "object" && !!(i as TWatchV3Metadata).data.media.domand,
+    v3DMC: (i: unknown): i is V3MetadataBody<"dmc"> =>
+      typeof i === "object" && !!(i as V3MetadataBody).media.delivery,
+    v3DMS: (i: unknown): i is V3MetadataBody<"dms"> =>
+      typeof i === "object" && !!(i as V3MetadataBody).media.domand,
   },
   renderer: {
     progress: (i: unknown): i is ApiResponseProgress =>

--- a/src/type-guard.ts
+++ b/src/type-guard.ts
@@ -28,9 +28,9 @@ const typeGuard = {
     message: (i: unknown): i is ApiResponseMessage =>
       typeof i === "object" && (i as ApiResponseMessage).type === "message",
     v3DMC: (i: unknown): i is V3MetadataBody<"dmc"> =>
-      typeof i === "object" && !!(i as V3MetadataBody).media.delivery,
+      typeof i === "object" && 'media' in (i as V3MetadataBody) && !!(i as V3MetadataBody).media.delivery,
     v3DMS: (i: unknown): i is V3MetadataBody<"dms"> =>
-      typeof i === "object" && !!(i as V3MetadataBody).media.domand,
+      typeof i === "object" && 'media' in i && !!(i as V3MetadataBody).media.domand,
   },
   renderer: {
     progress: (i: unknown): i is ApiResponseProgress =>


### PR DESCRIPTION
close #113 

- 従来のAPIを再生ページのjsonレスポンスから取得するように変更
- APIでは取得できないが再生ページでは表示できるデバイス規制対象動画に対応
