### PR TITLE
feat: 型ガード関数をZodスキーマベースの実装に移行

### DIFF
--- a/electron/type-guard.ts
+++ b/electron/type-guard.ts
@@ -51,7 +51,7 @@ const controllerSelectCommentSchema = z.object({
 const controllerSelectOutputSchema = z.object({
   host: z.literal("controller"),
   type: z.literal("selectOutput"),
-  options: z.any(), // SaveDialogOptions型
+  options: z.object({}).passthrough(), // SaveDialogOptions型。より具体的なスキーマを推奨します
 });
 
 const controllerSelectFileSchema = z.object({
@@ -112,7 +112,7 @@ const controllerGetNiconicoMovieMetadataSchema = z.object({
 const controllerInterruptQueueSchema = z.object({
   host: z.literal("controller"),
   type: z.literal("interruptQueue"),
-  queueId: z.string(), // UUID型
+  queueId: z.string().uuid(), // UUID型
 });
 
 const controllerGetQueueSchema = z.object({

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "electron-log": "^5.4.0",
     "electron-store": "^8.2.0",
     "jotai": "^2.12.3",
-    "sqlite3": "5.1.6"
+    "sqlite3": "5.1.6",
+    "zod": "^3.23.8"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.1.2",

--- a/src/type-guard.ts
+++ b/src/type-guard.ts
@@ -1,3 +1,5 @@
+import { z } from "zod";
+
 import type { V3MetadataBody } from "@/@types/niconico";
 import type { ApiResponseDownloadProgress } from "@/@types/response.binary-downloader";
 import type {
@@ -11,49 +13,119 @@ import type {
 } from "@/@types/response.controller";
 import type { ApiResponseReportProgress } from "@/@types/response.renderer";
 
+// Controller schemas
+const selectMovieSchema = z.object({
+  type: z.literal("selectMovie"),
+  data: z.any(), // Movie型は複雑なため部分検証
+});
+
+const selectCommentSchema = z.object({
+  type: z.literal("selectComment"),
+  path: z.string(),
+  format: z.any(), // CommentFormat型
+});
+
+const dropFilesSchema = z.object({
+  type: z.literal("dropFiles"),
+  movie: z.any().optional(), // Movie型
+  comment: z
+    .object({
+      path: z.string(),
+      format: z.any(),
+    })
+    .optional(),
+});
+
+const progressSchema = z.object({
+  type: z.literal("progress"),
+  data: z.any(), // Queue[]型は複雑なため部分検証
+});
+
+const startSchema = z.object({
+  type: z.literal("start"),
+});
+
+const endSchema = z.object({
+  type: z.literal("end"),
+});
+
+const messageSchema = z.object({
+  type: z.literal("message"),
+  title: z.string().optional(),
+  message: z.string(),
+});
+
+const v3DMCSchema = z.object({
+  media: z.object({
+    delivery: z.any(),
+  }),
+});
+
+const v3DMSSchema = z.object({
+  media: z.object({
+    domand: z.any(),
+  }),
+});
+
+// Renderer schemas
+const reportProgressSchema = z.object({
+  type: z.literal("reportProgress"),
+  progress: z.any(), // ProgressItem型
+});
+
+// BinaryDownloader schemas
+const downloadProgressSchema = z.object({
+  type: z.literal("downloadProgress"),
+  name: z.string(),
+  progress: z.number(),
+});
+
 const typeGuard = {
   controller: {
     selectMovie: (i: unknown): i is ApiResponseSelectMovie =>
       typeof i === "object" &&
-      (i as ApiResponseSelectMovie).type === "selectMovie",
+      i !== null &&
+      selectMovieSchema.safeParse(i).success,
     selectComment: (i: unknown): i is ApiResponseSelectComment =>
       typeof i === "object" &&
-      (i as ApiResponseSelectComment).type === "selectComment",
+      i !== null &&
+      selectCommentSchema.safeParse(i).success,
     dropFiles: (i: unknown): i is ApiResponseDropFiles =>
-      typeof i === "object" && (i as ApiResponseDropFiles).type === "dropFiles",
+      typeof i === "object" &&
+      i !== null &&
+      dropFilesSchema.safeParse(i).success,
     progress: (i: unknown): i is ApiResponseProgress =>
-      typeof i === "object" && (i as ApiResponseProgress).type === "progress",
+      typeof i === "object" &&
+      i !== null &&
+      progressSchema.safeParse(i).success,
     start: (i: unknown): i is ApiResponseStartController =>
-      typeof i === "object" &&
-      (i as ApiResponseStartController).type === "start",
+      typeof i === "object" && i !== null && startSchema.safeParse(i).success,
     end: (i: unknown): i is ApiResponseEnd =>
-      typeof i === "object" && (i as ApiResponseEnd).type === "end",
+      typeof i === "object" && i !== null && endSchema.safeParse(i).success,
     message: (i: unknown): i is ApiResponseMessage =>
-      typeof i === "object" && (i as ApiResponseMessage).type === "message",
+      typeof i === "object" && i !== null && messageSchema.safeParse(i).success,
     v3DMC: (i: unknown): i is V3MetadataBody<"dmc"> =>
-      typeof i === "object" &&
-      i !== null &&
-      "media" in (i as V3MetadataBody) &&
-      !!(i as V3MetadataBody).media.delivery,
+      typeof i === "object" && i !== null && v3DMCSchema.safeParse(i).success,
     v3DMS: (i: unknown): i is V3MetadataBody<"dms"> =>
-      typeof i === "object" &&
-      i !== null &&
-      "media" in (i as V3MetadataBody) &&
-      !!(i as V3MetadataBody).media.domand,
+      typeof i === "object" && i !== null && v3DMSSchema.safeParse(i).success,
   },
   renderer: {
     progress: (i: unknown): i is ApiResponseProgress =>
-      typeof i === "object" && (i as ApiResponseProgress).type === "progress",
+      typeof i === "object" &&
+      i !== null &&
+      progressSchema.safeParse(i).success,
     end: (i: unknown): i is ApiResponseEnd =>
-      typeof i === "object" && (i as ApiResponseEnd).type === "end",
+      typeof i === "object" && i !== null && endSchema.safeParse(i).success,
     reportProgress: (i: unknown): i is ApiResponseReportProgress =>
       typeof i === "object" &&
-      (i as ApiResponseReportProgress).type === "reportProgress",
+      i !== null &&
+      reportProgressSchema.safeParse(i).success,
   },
   binaryDownloader: {
     progress: (i: unknown): i is ApiResponseDownloadProgress =>
       typeof i === "object" &&
-      (i as ApiResponseDownloadProgress).type === "downloadProgress",
+      i !== null &&
+      downloadProgressSchema.safeParse(i).success,
   },
 };
 

--- a/src/type-guard.ts
+++ b/src/type-guard.ts
@@ -57,7 +57,7 @@ const messageSchema = z.object({
 
 const v3DMCSchema = z.object({
   media: z.object({
-    delivery: z.any(),
+    delivery: z.object({}).passthrough(),
   }),
 });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -276,7 +276,6 @@
 
 "@electron/node-gyp@https://github.com/electron/node-gyp#06b29aafb7708acef8b3669835c8a7857ebc92d2":
   version "10.2.0-electron.1"
-  uid "06b29aafb7708acef8b3669835c8a7857ebc92d2"
   resolved "https://github.com/electron/node-gyp#06b29aafb7708acef8b3669835c8a7857ebc92d2"
   dependencies:
     env-paths "^2.2.0"
@@ -4327,16 +4326,7 @@ statuses@2.0.1:
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-2.0.1.tgz#55cb000ccf1d48728bd23c685a063998cf1a1b63"
   integrity sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -4373,14 +4363,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -4716,16 +4699,7 @@ win-protect@^1.0.0:
   resolved "https://registry.yarnpkg.com/win-protect/-/win-protect-1.0.0.tgz#bee4414e0c61c26909abfc38e57c589d5721a590"
   integrity sha512-G5Ho9mVkxSES7MOVsR9QoeNexwF6w+CdBsUg9CGOW1QqkCYFSZJ5ecRFj3osyMbESo4EURAyKjaIURlgKfvNaw==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -4831,3 +4805,8 @@ yocto-queue@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
+
+zod@^3.23.8:
+  version "3.25.76"
+  resolved "https://registry.yarnpkg.com/zod/-/zod-3.25.76.tgz#26841c3f6fd22a6a2760e7ccb719179768471e34"
+  integrity sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==


### PR DESCRIPTION
## 概要
`src/type-guard.ts`と`electron/type-guard.ts`の型ガード関数をZodスキーマベースの実装に移行しました。
## 変更内容
- package.jsonにzodを依存関係として追加
- src/type-guard.tsをZodスキーマベースの実装に移行  
- controller: 9種類（selectMovie, selectComment, dropFiles, progress, start, end, message, v3DMC, v3DMS）  
- renderer: 3種類（progress, end, reportProgress）  
- binaryDownloader: 1種類（progress）
- electron/type-guard.tsをZodスキーマベースの実装に移行  
- controller: 14種類のリクエスト型  
- renderer: 5種類のリクエスト型  
- firefox: 2種類（containers, defaultContainer）  
- chromium: 1種類（profiles）  
- niconico: 7種類（userData, TWatchV3Metadata, WatchPageJson, CreateSessionResponse, v3DMC, v3DMS, v1AccessRightsHls）  
- cookie: 1種類（parsedCookieKey）
## 互換性
- 既存の型ガード関数のインターフェース（`(i: unknown): i is Type`）は維持
- 既存の使用箇所（17ファイル）は変更不要
- 型チェックとリンターエラーなし