### PR TITLE
fix: 投稿者コメントのuser_id属性を出力しないよう修正

### DIFF
--- a/electron/lib/niconico/comments/comments.ts
+++ b/electron/lib/niconico/comments/comments.ts
@@ -67,7 +67,10 @@ const convertToXml = (comments: FormattedComment[]): string => {
           vpos: comment.vpos,
           date: comment.date,
           date_usec: comment.date_usec,
-          user_id: comment.user_id,
+          // 投稿者コメントは user_id 属性が存在しないことで判定されるため、
+          // 内部的に割り当てた匿名の user_id を出力に含めない
+          // https://github.com/xpadev-net/niconicomments-convert/issues/357
+          user_id: comment.owner ? undefined : comment.user_id,
           mail: comment.mail.join(" "),
           premium: comment.premium ? 1 : 0,
           anonymity: comment.owner ? 1 : 0,


### PR DESCRIPTION
## Summary
- ダウンロードしたコメントXMLを再度読み込んだ際、投稿者コメントが投稿者コメントとして認識されない不具合を修正
- `convertToXml` が投稿者コメントにも内部的に割り当てた匿名の `user_id`（先頭に処理されると `0` になりやすい）を書き出していたのが原因
- `@xpadev-net/niconicomments` は `user_id` 属性が存在しないコメントを投稿者コメントとして扱うため、投稿者コメントの場合は `user_id` 属性自体を出力しないよう修正

## Test plan
- [x] `pnpm run check-types`
- [x] `pnpm run lint`
- [ ] 実際に動画のコメントをダウンロードし、再エンコード時に投稿者コメントが正しく認識されることを確認

Closes #357

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR changes XML serialization so uploader comments omit their internally assigned anonymous `user_id`, allowing them to be recognized correctly when the downloaded XML is loaded again.
- Uses the existing `owner` flag to conditionally omit `user_id`.
- Preserves `user_id` serialization for ordinary comments.
- Documents the round-trip compatibility reason and links the associated issue.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because no concrete blocking or independently actionable issue was established.

The change is narrowly scoped to owner-comment XML serialization and retains the existing behavior for ordinary comments, with no supported reachable failure remaining.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| electron/lib/niconico/comments/comments.ts | Conditionally omits the `user_id` XML attribute for owner comments; no concrete defect was established from the available repository evidence. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: omit user\_id attribute for owner co..."](https://github.com/xpadev-net/niconicomments-convert/commit/28e1d88678e89160b783d75520bcf645102dfb41) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54816375)</sub>

<!-- /greptile_comment -->