### PR TITLE
chore(renovate): set minimumReleaseAge to 7 days

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,6 @@ jobs:
         
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
-        with:
-          version: 11.22.0
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -45,8 +43,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
-        with:
-          version: 11.22.0
 
       - name: Setup Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -30,8 +30,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
-        with:
-          version: 11.22.0
 
       - name: Setup node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,8 +12,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v6
-        with:
-          version: 11.22.0
       - uses: actions/setup-node@v6
         with:
           node-version: 24
@@ -37,8 +35,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v6
-        with:
-          version: 11.22.0
       - uses: actions/setup-node@v6
         with:
           node-version: 24
@@ -68,8 +64,6 @@ jobs:
           ref: ${{ github.event_name == 'workflow_dispatch' && 'develop' || github.ref }}
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
-        with:
-          version: 11.22.0
 
       - name: Setup node.js
         uses: actions/setup-node@v6

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "niconicomments-convert",
   "private": false,
   "version": "0.0.34",
-  "packageManager": "pnpm@11.22.0",
+  "packageManager": "pnpm@11.2.2",
   "type": "commonjs",
   "license": "MIT",
   "main": "build/electron/electron.js",

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
+  "minimumReleaseAge": "7 days",
   "packageRules": [
     {
       "matchUpdateTypes": ["patch"],


### PR DESCRIPTION
## Summary
- Add top-level `minimumReleaseAge: "7 days"` to `renovate.json`, matching the setting already used in [niconicomments](https://github.com/xpadev-net/niconicomments)'s renovate config, so Renovate waits 7 days after a package release before opening an update PR.
- Pin `packageManager` back to `pnpm@11.2.2` in `package.json`. It had been bumped to `pnpm@11.22.0`, which is too recently published to satisfy the local pnpm `minimumReleaseAge` policy, so `pnpm install` (and the lefthook pre-commit `lint` step) failed until it downgraded.

## Test plan
- [x] `pnpm install` / lefthook pre-commit `lint` hook runs successfully with `pnpm@11.2.2`
- [ ] Confirm Renovate picks up the new `minimumReleaseAge` setting on its next run

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR centralizes the pnpm version in `package.json` for local and GitHub Actions usage and configures Renovate to wait seven days before proposing newly released dependencies.
- Pins the package manager to `pnpm@11.2.2`.
- Removes duplicated pnpm version inputs from CI and release workflows.
- Adds a global seven-day minimum release age to Renovate.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable correctness or security issues identified.

The package-manager declaration and workflow setup are aligned on pnpm 11.2.2, and the Renovate delay implements the behavior stated in the PR description without breaking an established repository contract.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| package.json | Downgrades the declared pnpm version to 11.2.2, which becomes the shared version source for local and workflow installs. |
| renovate.json | Adds the intended global seven-day minimum release age while preserving the existing package and vulnerability-alert rules. |
| .github/workflows/ci.yml | Removes hardcoded pnpm versions so both CI jobs use the version declared in `package.json`. |
| .github/workflows/create-release.yml | Makes the release-creation workflow derive its pnpm version from `package.json`. |
| .github/workflows/release.yml | Makes all release jobs derive their pnpm version from `package.json`, keeping package-manager selection consistent. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ci): let pnpm/action-setup read vers..."](https://github.com/xpadev-net/niconicomments-convert/commit/5592425bda744965ed40d493d37ad166392a63c3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55616072)</sub>

<!-- /greptile_comment -->